### PR TITLE
#22: Exclude jest setup files and storybook stories from coverage report

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,9 @@ module.exports = {
   // collectCoverageFrom: null,
   collectCoverageFrom: [
     "<rootDir>/src/**/*.{js,jsx}",
-    "!<rootDir>/node_modules/"
+		"!<rootDir>/node_modules/",
+		"!<rootDir>/src/__tests__/setup/**/*.js",
+		"!<rootDir>/src/stories/**/*.js"
   ],
 
   // The directory where Jest should output its coverage files


### PR DESCRIPTION
Excluded jest setup files and storybook stories from coverage report. Closes #22 